### PR TITLE
feat: forward websockets/spdy with http1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -77,4 +77,4 @@ static_resources:
         common_tls_context:
           validation_context:
             trusted_ca:
-              filename: /usr/local/etc/envoy/target-tls.cert
+              filename: /usr/local/etc/envoy/target-tls.crt

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -47,7 +47,7 @@ static_resources:
               - match:
                   prefix: /
                 route:
-                  cluster: apiserver
+                  cluster: cluster
                   timeout: 2592000s
       transport_socket:
         name: envoy.transport_sockets.tls

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -57,6 +57,9 @@ static_resources:
             validation_context:
               trusted_ca:
                 filename: /usr/local/etc/envoy/target-tls.crt
+            alpn_protocols:
+            - h2
+            - http/1.1
   clusters:
   - name: cluster
     connect_timeout: 15s
@@ -84,3 +87,6 @@ static_resources:
           validation_context:
             trusted_ca:
               filename: /usr/local/etc/envoy/target-tls.crt
+          alpn_protocols:
+          - h2
+          - http/1.1

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -24,9 +24,6 @@ static_resources:
               log_format:
                 text_format_source:
                   inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH):256% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %ROUTE_NAME% %BYTES_RECEIVED% %BYTES_SENT% %UPSTREAM_WIRE_BYTES_RECEIVED% %UPSTREAM_WIRE_BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\"  \"%REQ(:AUTHORITY)%\"\n"
-          upgrade_configs:
-          - upgrade_type: spdy/3.1 # support for Kubernetes streams
-          - upgrade_type: websocket
           route_config:
             name: local_route
             response_headers_to_add:
@@ -40,9 +37,21 @@ static_resources:
               - '*'
               routes:
               - match:
+                  headers:
+                  - name: Upgrade
+                  - exact_match: Upgrade
+                    name: Connection
                   prefix: /
                 route:
-                  cluster: cluster
+                  cluster: cluster-h1
+                  timeout: 2592000s
+                  upgrade_configs:
+                  - upgrade_type: spdy/3.1
+                  - upgrade_type: websocket
+              - match:
+                  prefix: /
+                route:
+                  cluster: cluster-h2
                   timeout: 2592000s
       transport_socket:
         name: envoy.transport_sockets.tls
@@ -61,8 +70,34 @@ static_resources:
             - h2
             - http/1.1
   clusters:
-  - name: cluster
-    connect_timeout: 15s
+  - name: cluster-h1
+    type: LOGICAL_DNS
+    dns_lookup_family: V4_ONLY
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http_protocol_options: {}
+    load_assignment:
+      cluster_name: cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: __TMPL_TARGET_HOST__
+                port_value: __TMPL_TARGET_PORT__
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          validation_context:
+            trusted_ca:
+              filename: /usr/local/etc/envoy/target-tls.crt
+          alpn_protocols:
+          - http/1.1
+  - name: cluster-h2
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY
     typed_extension_protocol_options:

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -40,11 +40,6 @@ static_resources:
               - '*'
               routes:
               - match:
-                  prefix: /envoy-admin/
-                route:
-                  cluster: envoy-admin
-                  prefix_rewrite: /
-              - match:
                   prefix: /
                 route:
                   cluster: cluster
@@ -89,26 +84,3 @@ static_resources:
           validation_context:
             trusted_ca:
               filename: /usr/local/etc/envoy/target-tls.crt
-  - name: envoy-admin
-    connect_timeout: 15s
-    type: LOGICAL_DNS
-    dns_lookup_family: V4_ONLY
-    typed_extension_protocol_options:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-        explicit_http_config:
-          http2_protocol_options: {}
-    load_assignment:
-      cluster_name: envoy-admin
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: 127.0.0.1
-                port_value: 9901
-admin:
-  address:
-    socket_address:
-      address: 127.0.0.1
-      port_value: 9901

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -83,7 +83,7 @@ static_resources:
           validation_context:
             trusted_ca:
               filename: /usr/local/etc/envoy/target-tls.crt
-  - name: admin
+  - name: envoy-admin
     connect_timeout: 15s
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -11,6 +11,7 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           codec_type: auto
           stat_prefix: ingress_http
+          stream_idle_timeout: 2592000s
           http_filters:
           - name: envoy.filters.http.router
             typed_config:
@@ -24,6 +25,7 @@ static_resources:
                 text_format_source:
                   inline_string: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH):256% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %ROUTE_NAME% %BYTES_RECEIVED% %BYTES_SENT% %UPSTREAM_WIRE_BYTES_RECEIVED% %UPSTREAM_WIRE_BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\"  \"%REQ(:AUTHORITY)%\"\n"
           upgrade_configs:
+          - upgrade_type: spdy/3.1 # support for Kubernetes streams
           - upgrade_type: websocket
           route_config:
             name: local_route
@@ -33,7 +35,7 @@ static_resources:
                   value: "%HOSTNAME%"
                 append_action: OVERWRITE_IF_EXISTS_OR_ADD
             virtual_hosts:
-            - name: listener_0
+            - name: listener
               domains:
               - '*'
               routes:
@@ -45,7 +47,8 @@ static_resources:
               - match:
                   prefix: /
                 route:
-                  cluster: cluster_0
+                  cluster: apiserver
+                  timeout: 2592000s
       transport_socket:
         name: envoy.transport_sockets.tls
         typed_config:
@@ -56,8 +59,11 @@ static_resources:
                 filename: /usr/local/etc/envoy/bind-tls.crt
               private_key:
                 filename: /usr/local/etc/envoy/bind-tls.key
+            validation_context:
+              trusted_ca:
+                filename: /usr/local/etc/envoy/target-tls.crt
   clusters:
-  - name: cluster_0
+  - name: cluster
     connect_timeout: 15s
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY
@@ -67,7 +73,7 @@ static_resources:
         explicit_http_config:
           http_protocol_options: {}
     load_assignment:
-      cluster_name: cluster_0
+      cluster_name: cluster
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -91,9 +97,9 @@ static_resources:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicit_http_config:
-          http_protocol_options: {}
+          http2_protocol_options: {}
     load_assignment:
-      cluster_name: cluster_0
+      cluster_name: envoy-admin
       endpoints:
       - lb_endpoints:
         - endpoint:

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -66,7 +66,7 @@ static_resources:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicit_http_config:
-          http_protocol_options: {}
+          http2_protocol_options: {}
     load_assignment:
       cluster_name: cluster
       endpoints:

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -38,6 +38,11 @@ static_resources:
               - '*'
               routes:
               - match:
+                  prefix: /envoy-admin/
+                route:
+                  cluster: envoy-admin
+                  prefix_rewrite: /
+              - match:
                   prefix: /
                 route:
                   cluster: cluster_0
@@ -78,3 +83,26 @@ static_resources:
           validation_context:
             trusted_ca:
               filename: /usr/local/etc/envoy/target-tls.crt
+  - name: admin
+    connect_timeout: 15s
+    type: LOGICAL_DNS
+    dns_lookup_family: V4_ONLY
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http_protocol_options: {}
+    load_assignment:
+      cluster_name: cluster_0
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 9901
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9901

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -60,7 +60,7 @@ static_resources:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
         explicit_http_config:
-          http2_protocol_options: {}
+          http_protocol_options: {}
     load_assignment:
       cluster_name: cluster_0
       endpoints:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,7 @@ BIND_PORT=${BIND_PORT:-8443}
 
 echo "${BIND_TLS_CERT_B64}" | base64 -d > /usr/local/etc/envoy/bind-tls.crt
 echo "${BIND_TLS_KEY_B64}" | base64 -d > /usr/local/etc/envoy/bind-tls.key
-echo "${TARGET_TLS_CERT_B64}" | base64 -d > /usr/local/etc/envoy/target-tls.cert
+echo "${TARGET_TLS_CERT_B64}" | base64 -d > /usr/local/etc/envoy/target-tls.crt
 
 sed \
   -e "s/__TMPL_BIND_ADDRESS__/$BIND_ADDRESS/g" \


### PR DESCRIPTION
- upgrade websocket & spdy connections, see https://github.com/envoyproxy/envoy/issues/11190
- forward upgraded connections to http1 backend
- use a large timeout