### PR TITLE
fix: make header match insensitive to case

### DIFF
--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -50,6 +50,7 @@ static_resources:
                   timeout: 3600s
                   upgrade_configs:
                   - upgrade_type: spdy/3.1
+                  - upgrade_type: SPDY/3.1
                   - upgrade_type: websocket
               - match:
                   prefix: /

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -43,13 +43,14 @@ static_resources:
                   - name: Upgrade
                   - string_match:
                       exact: Upgrade
+                      ignore_case: true
                     name: Connection
                   prefix: /
                 route:
                   cluster: cluster-h1
                   timeout: 3600s
                   upgrade_configs:
-                  - upgrade_type: SPDY/3.1
+                  - upgrade_type: spdy/3.1
                   - upgrade_type: websocket
               - match:
                   prefix: /

--- a/config.yml.tmpl
+++ b/config.yml.tmpl
@@ -49,7 +49,6 @@ static_resources:
                   cluster: cluster-h1
                   timeout: 3600s
                   upgrade_configs:
-                  - upgrade_type: spdy/3.1
                   - upgrade_type: SPDY/3.1
                   - upgrade_type: websocket
               - match:


### PR DESCRIPTION
Azure AppGateway rewrites `Connection: Upgrade` into `Connection: upgrade` which breaks the upgrade detection.

Disabling case sensitiveness for this match makes this proxy allow upgrades behind AppGateway.